### PR TITLE
Added netstat alternative

### DIFF
--- a/09-network/lab/README.md
+++ b/09-network/lab/README.md
@@ -115,6 +115,10 @@ public class CommandExecutionServer implements AutoCloseable {
 ```
 netstat -an
 ```
+или ако сте на Linux:
+```
+ss -an
+```
 След това спрете сървъра.
 
 5. Имплементирайте метода `start`. В този метод трябва да извиквате `selector.select()` и да итерирате по селектираните канали, като обработвате OP_ACCEPT и OP_READ операции. За повече информация, вижте [тук](https://gitpitch.com/fmi/java-course/master?p=09-network/lecture/#/39). Не забравяйте да извикате метода `start` в `main` метода.


### PR DESCRIPTION
On Linux `netstat` is part of the `net-tools` package, [which has been unmaintaned for years](https://dougvitale.wordpress.com/2011/12/21/deprecated-linux-networking-commands-and-their-replacements/).
`net-tools` is not preinstalled on debian-stable nor on ubuntu 18.10 (unlike `ss`) and it's not available in the [arch linux repositories](https://www.archlinux.org/news/deprecation-of-net-tools/).
As per its [manual page](https://linux.die.net/man/8/netstat):
> This program is obsolete. Replacement for netstat is ss. ...

This commit adds the suggestion of using the preferred alternative `ss`.