### PR TITLE
Remove unnecessary object creation (Lab11 snippet)

### DIFF
--- a/11-http-rest/snippets/AsyncSongLyricsRetriever.java
+++ b/11-http-rest/snippets/AsyncSongLyricsRetriever.java
@@ -37,7 +37,7 @@ public class AsyncSongLyricsRetriever {
     }
 
     public static void main(String... args) throws Exception {
-        new AsyncSongLyricsRetriever().getLyricsAsync("Billie Eilish", "Lovely");
+        AsyncSongLyricsRetriever.getLyricsAsync("Billie Eilish", "Lovely");
     }
 
 }


### PR DESCRIPTION
An object is only required for the synchronized version of this snippet (here we have a static method)