### PR TITLE
Add missing exception to method javadoc

### DIFF
--- a/07-io-streams-and-files/lab/README.md
+++ b/07-io-streams-and-files/lab/README.md
@@ -31,6 +31,7 @@ public interface ImageAlgorithm {
      * Applies the image processing algorithm to the given image.
      *
      * @param image the image to be processed
+	 * @throws IllegalArgumentException if the image is null
      * @return BufferedImage the processed image of type (TYPE_INT_RGB)
      */
     BufferedImage process(BufferedImage image);


### PR DESCRIPTION
The codepost.io tests the method with null image, but is not described in the javadoc