### PR TITLE
Add missing exception to method javadoc

### DIFF
--- a/07-io-streams-and-files/lab/README.md
+++ b/07-io-streams-and-files/lab/README.md
@@ -32,6 +32,7 @@ public interface ImageAlgorithm {
      *
      * @param image the image to be processed
      * @return BufferedImage the processed image of type (TYPE_INT_RGB)
+     * @throws IllegalArgumentException if the image is null
      */
     BufferedImage process(BufferedImage image);
 }


### PR DESCRIPTION
The codepost.io tests the method with null image, but is not described in the javadoc