### PR TITLE
Fix inconsistency in README

### DIFF
--- a/09-threads/lab/README.md
+++ b/09-threads/lab/README.md
@@ -48,7 +48,7 @@ Consumer нишките ни ще имат фиксиран брой `N` и за
 ### Лексикон и стоп-думи
 Качили сме два файла, които може да ползвате за по-истински анализ. Намират се в директорията `resources`.
 
-### Interface `SemanticAnalyzerAPI`
+### Interface `SentimentAnalyzerAPI`
 
 ```java
 package bg.sofia.uni.fmi.mjt.sentimentnalyzer;


### PR DESCRIPTION
Changed 'SemanticAnalyzerAPI' to 'SentimentAnalyzerAPI' to match the name of the interface in the code block.