### PR TITLE
Fix ParallelSentimentAnalyzer constructor argument

### DIFF
--- a/09-threads/lab/README.md
+++ b/09-threads/lab/README.md
@@ -162,7 +162,7 @@ public enum SentimentScore {
  * @param stopWords set containing stop words
  * @param sentimentLexicon map containing the sentiment lexicon, where the key is the word and the value is the sentiment score
  */
-public ParallelSentimentAnalyzer(int workersCount, Set<String> stopWords, Map<String, Integer> sentimentLexicon) { }
+public ParallelSentimentAnalyzer(int workersCount, Set<String> stopWords, Map<String, SentimentScore> sentimentLexicon) { }
 ```
 
 ⭐ Бележки:

--- a/09-threads/lab/README.md
+++ b/09-threads/lab/README.md
@@ -187,7 +187,7 @@ public ParallelSentimentAnalyzer(int workersCount, Set<String> stopWords, Map<St
 
 ```
 src
-└─ bg.sofia.uni.fmi.mjt.sentimentnalyzer
+└─ bg.sofia.uni.fmi.mjt.sentimentanalyzer
     ├── exceptions
     |   └── SentimentAnalysisException.java
     ├── SentimentAnalyzerAPI.java


### PR DESCRIPTION
`testAnalyzeWithMultipleInputs()` is calling `ParallelSentimentAnalyzer` constructor with `Map<String, SentimentScore>`, but the constructor takes `Map<String, Integer>`.
I'm assuming the test is correctly passing a `Map<String, SentimentScore>` and the constructor is incorrect.