### PR TITLE
Add possible minor change to Math Calculations in HW02 readme

### DIFF
--- a/homeworks/02-goodreads/tfidf.md
+++ b/homeworks/02-goodreads/tfidf.md
@@ -34,7 +34,7 @@ Book Z with description "crime murder mystery club"
 Отговор:
 
 ```
-IDF('superhero',All books) = log(3/2) = log(1.5) = 0.17
+IDF('superhero',All books) = log10(3/2) = log10(1.5) = 0.17
 ```
 
 ### TF-IDF


### PR DESCRIPTION
In the previous version, the logarithm calculation was denoted as `log(3/2)` which might be confused with `ln(3/2)`, instead of the desired `log10(3/2)`